### PR TITLE
Add inline admin notice to the plugin row on WordPress 7.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Workaround for sites experiencing issues with WordPress 6.9's changed default be
 **Contributors:** [westonruter](https://profile.wordpress.org/westonruter)  
 **Tags:**         performance  
 **Tested up to:** 7.0  
-**Stable tag:**   1.0.0  
+**Stable tag:**   1.1.0  
 **License:**      [GPLv2 or later](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 ## Description
@@ -43,6 +43,10 @@ You may also install and update via [Git Updater](https://git-updater.com/) usin
 5. Click the **Activate Plugin** button.
 
 ## Changelog
+
+### 1.1.0
+
+* Add inline admin notice with plugin row on WordPress 7.0+ to encourage re-evaluating whether still necessary.
 
 ### 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Load Combined Core Block Assets
 
-Temporary workaround for sites experiencing issues with WordPress 6.9's new ability to load block styles on demand in classic themes.
+Workaround for sites experiencing issues with WordPress 6.9's changed default behavior to load block styles on demand in classic themes.
 
 **Contributors:** [westonruter](https://profile.wordpress.org/westonruter)  
 **Tags:**         performance  
@@ -10,13 +10,19 @@ Temporary workaround for sites experiencing issues with WordPress 6.9's new abil
 
 ## Description
 
-This is a temporary workaround for sites experiencing any issues with WordPress 6.9's new ability to [load block styles on demand in classic themes](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes), for example [#64354](https://core.trac.wordpress.org/ticket/64354).
+This is a workaround for sites experiencing any issues with ability introduced in WordPress 6.9 to [load block styles on demand in classic themes](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes). The known issues have been fixed during the 7.0 release release cycle with the following commits:
 
-If running a classic theme (i.e. not a block theme), it filters `should_load_separate_core_block_assets` to be `false`. This has the effect of reverting a change introduced in 6.9 where classic themes now load separate core block assets on demand by default.
+* [r61076](https://core.trac.wordpress.org/changeset/61076): Script Loader: Fall back to hoisting late-printed styles to end of HEAD if wp-block-library is not enqueued.
+* [r61122](https://core.trac.wordpress.org/changeset/61122): Script Loader: Load block styles on demand in classic themes even when wp-block-styles support is absent.
+* [r61174](https://core.trac.wordpress.org/changeset/61174): Script Loader: Improve hoisted stylesheet ordering (in classic themes) to preserve CSS cascade.
+* [r61554](https://core.trac.wordpress.org/changeset/61554): Script Loader: Preserve original CSS cascade for classic themes when hoisting late-printed styles.
+* [r61945](https://core.trac.wordpress.org/changeset/61945): Script Loader: Refine hoisted stylesheet ordering to preserve original CSS cascade in classic themes.
 
-Note that this plugin should be considered temporary until any issues are resolved in 6.9.1. At any time, you can test whether any issues remain by adding `?should_load_separate_core_block_assets=true` to any frontend URL; this restores the default behavior in WP 6.9. 
+If running a classic theme (i.e. not a block theme), this plugin filters `should_load_separate_core_block_assets` to be `false`. This has the effect of reverting a change introduced in 6.9 where classic themes now load separate core block assets on demand by default.
 
-This workaround is temporary because there are performance benefits to loading separate core block assets. They can be loaded on demand just when they are used, as opposed to loading the large single combined `wp-block-library` stylesheet. Loading separate block styles on demand reduces the amount of CSS which should improve page load time.
+Note that this plugin should be considered temporary until any issues are resolved in 7.0. At any time, you can test whether any issues remain by adding `?should_load_separate_core_block_assets=true` to any frontend URL; this restores the default behavior in WP 6.9. 
+
+This workaround should be temporary because there are performance benefits to loading separate core block assets. They can be loaded on demand just when they are used, as opposed to loading the large single combined `wp-block-library` stylesheet. Loading separate block styles on demand reduces the amount of CSS which should improve page load time. Nevertheless, as explained in the [dev note](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes), some sites may be built in a way that fundamentally does not work with loading separate block styles on demand. For these sites, this plugin is available to retain the old behavior.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You may also install and update via [Git Updater](https://git-updater.com/) usin
 
 ### 1.1.0
 
-* Add inline admin notice with plugin row on WordPress 7.0+ to encourage re-evaluating whether still necessary.
+* Add an inline admin notice in the plugin list table row on WordPress 7.0+ to encourage re-evaluating whether the plugin is still necessary.
 
 ### 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Workaround for sites experiencing issues with WordPress 6.9's changed default be
 
 ## Description
 
-This is a workaround for sites experiencing any issues with ability introduced in WordPress 6.9 to [load block styles on demand in classic themes](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes). The known issues have been fixed during the 7.0 release release cycle with the following commits:
+This is a workaround for sites experiencing any issues with the ability introduced in WordPress 6.9 to [load block styles on demand in classic themes](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes). The known issues have been fixed during the 7.0 release cycle with the following commits:
 
 * [r61076](https://core.trac.wordpress.org/changeset/61076): Script Loader: Fall back to hoisting late-printed styles to end of HEAD if wp-block-library is not enqueued.
 * [r61122](https://core.trac.wordpress.org/changeset/61122): Script Loader: Load block styles on demand in classic themes even when wp-block-styles support is absent.

--- a/load-combined-core-block-assets.php
+++ b/load-combined-core-block-assets.php
@@ -98,3 +98,49 @@ function filter_style_loader_tag( $tag, string $handle ): string {
 }
 
 add_filter( 'style_loader_tag', __NAMESPACE__ . '\filter_style_loader_tag', 10, 2 );
+
+/**
+ * Prints an inline info notice in the plugin's row on the Plugins screen.
+ *
+ * Since this plugin is intended to be a temporary workaround while the known
+ * issues are ironed out during the 7.0 release cycle, this notice encourages
+ * users to verify whether anything is still broken with the default 6.9
+ * behavior and where to report any remaining issues. The notice is only shown
+ * on WordPress 7.0-RC1 or later, by which point the known issues are fixed.
+ *
+ * @since 1.1.0
+ *
+ * @param string $plugin_file Plugin file path relative to the plugins directory.
+ *
+ * @return void
+ */
+function print_plugin_row_notice( string $plugin_file ) { // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint
+	if ( plugin_basename( __FILE__ ) !== $plugin_file ) {
+		return;
+	}
+
+	if ( version_compare( wp_get_wp_version(), '7.0-RC1', '<' ) ) {
+		return;
+	}
+
+	$test_url    = add_query_arg( 'should_load_separate_core_block_assets', 'true', home_url( '/' ) );
+	$support_url = 'https://wordpress.org/support/plugin/load-combined-core-block-assets/';
+
+	$message = sprintf(
+		/* translators: 1: URL to the site homepage with the query parameter, 2: ?should_load_separate_core_block_assets=true, 3: URL to the support forum */
+		__( 'This plugin is intended to be a temporary workaround while issues are ironed out during the WordPress 7.0 release cycle. Now that the known issues are fixed, please <a href="%1$s">visit your site</a> with <code>%2$s</code> appended to the URL to check whether anything is still amiss without this workaround. If you still experience issues, please <a href="%3$s" target="_blank" rel="noopener">open a topic on the support forum</a>.', 'load-combined-core-block-assets' ),
+		esc_url( $test_url ),
+		'?should_load_separate_core_block_assets=true',
+		esc_url( $support_url )
+	);
+
+	wp_admin_notice(
+		wp_kses_post( $message ),
+		array(
+			'type'               => 'info',
+			'additional_classes' => array( 'inline' ),
+		)
+	);
+}
+
+add_action( 'after_plugin_row_meta', __NAMESPACE__ . '\print_plugin_row_notice' );

--- a/load-combined-core-block-assets.php
+++ b/load-combined-core-block-assets.php
@@ -40,10 +40,8 @@ const VERSION = '1.1.0';
  * Inits plugin.
  *
  * @since 0.1.0
- *
- * @return void
  */
-function init() { // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint
+function init(): void {
 	if ( wp_is_block_theme() ) {
 		return;
 	}
@@ -111,10 +109,8 @@ add_filter( 'style_loader_tag', __NAMESPACE__ . '\filter_style_loader_tag', 10, 
  * @since 1.1.0
  *
  * @param string $plugin_file Plugin file path relative to the plugins directory.
- *
- * @return void
  */
-function print_plugin_row_notice( string $plugin_file ) { // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint
+function print_plugin_row_notice( string $plugin_file ): void {
 	if ( plugin_basename( __FILE__ ) !== $plugin_file ) {
 		return;
 	}

--- a/load-combined-core-block-assets.php
+++ b/load-combined-core-block-assets.php
@@ -13,7 +13,7 @@
  * Description: Temporary workaround for sites experiencing issues with WordPress 6.9's new ability to <a href="https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/#load-block-styles-on-demand-in-classic-themes">load block styles on demand in classic themes</a>.
  * Requires at least: 6.9
  * Requires PHP: 7.2
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Weston Ruter
  * Author URI: https://weston.ruter.net/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  * @var string
  */
-const VERSION = '1.0.0';
+const VERSION = '1.1.0';
 
 /**
  * Inits plugin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-combined-core-block-assets",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Temporary workaround for sites experiencing issues with WordPress 6.9's new ability to load block styles on demand in classic themes.",
 	"private": true,
 	"author": "Weston Ruter",


### PR DESCRIPTION
## Summary

Adds an inline info notice in this plugin's row on the **Plugins** screen, hooked into `after_plugin_row_meta` and rendered via `wp_admin_notice()`.

Since this plugin is a temporary workaround while the issues are ironed out during the WordPress 7.0 release cycle, the notice nudges users to re-evaluate whether they still need it:

- It is only shown on **WordPress 7.0-RC1 or later** (`version_compare( wp_get_wp_version(), '7.0-RC1', '<' )`), by which point the known issues are fixed.
- It links to the site homepage with `?should_load_separate_core_block_assets=true` appended so users can verify whether anything is still amiss without the workaround.
- It links to the [support forum](https://wordpress.org/support/plugin/load-combined-core-block-assets/) for reporting any remaining issues.

## Notes

- Link markup lives inside the translatable strings (core i18n convention), with only URLs passed as `sprintf` placeholders; `esc_url()` on URLs and `wp_kses_post()` on the assembled message.
- Passes the plugin's PHPCS and PHPStan configs.
- The 1.1.0 version bump (plugin header, `VERSION` constant, `package.json`, stable tags, `readme.txt` changelog) is also part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
